### PR TITLE
Upgraded alpine to 3.8.

### DIFF
--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -1,13 +1,15 @@
-FROM alpine:3.4
+FROM alpine:3.8
 
 MAINTAINER Wang Shaobo <fireshooter@163.com>
 
 ENV LANG en_US.UTF-8
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
+RUN apk update
+
 ENV NGINX_VERSION 1.10.2
 ENV NGX_DEVEL_KIT_VERSION 0.3.0
-ENV LUA_NGINX_MODULE_VERSION 0.10.7
+ENV LUA_NGINX_MODULE_VERSION 0.10.15
 
 # Install LUAJIT
 RUN apk add --no-cache luajit
@@ -77,7 +79,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		perl-dev \
 		luajit-dev \
 	&& export LUAJIT_LIB=/usr/lib \
-	&& export LUAJIT_INC=/usr/include/luajit-2.0 \
+	&& export LUAJIT_INC=/usr/include/luajit-2.1 \
 	&& curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v0.3.0.tar.gz -o /tmp/ndk.tar.gz \
 	&& tar -xvf /tmp/ndk.tar.gz -C /tmp \
 	&& curl -fSL https://github.com/openresty/lua-nginx-module/archive/v${LUA_NGINX_MODULE_VERSION}.tar.gz -o /tmp/lua-nginx.tar.gz \


### PR DESCRIPTION
Based on this ([CVE-2019-5021](https://cve.circl.lu/cve/CVE-2019-5021)) vulnerability report on alpine and this [report](https://www.alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html) from alpine about affected versions, I upgraded base image for alpine version to 3.8.

For this also was needed to upgrade LUA nginx module and luajit versions.

Additionally, I added a `RUN apk update`, because, if this update is not made, during the build process, a message was arisen about problems with `apk add` commands.