### PR TITLE
Update/ Multiple updates

### DIFF
--- a/.github/workflows/dockerimage-test.yml
+++ b/.github/workflows/dockerimage-test.yml
@@ -19,5 +19,5 @@ jobs:
         echo "[DEBUG] Building..."
         docker build -t nginx-lua:alpine-test .
         echo "[DEBUG] Testing..."
-        docker run  --entrypoint nginx nginx-lua:alpine-test -version | tee nginx.version
+        echo $(docker run  --entrypoint nginx nginx-lua:alpine-test -version 2>&1 | tee nginx.version
         if [[ $(cat nginx.version | grep "nginx/1.24.0" | wc -l) -le 0 ]]; then exit 1; fi

--- a/.github/workflows/dockerimage-test.yml
+++ b/.github/workflows/dockerimage-test.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test docker image
+      run: |
+        cd stable/alpine
+        echo "[DEBUG] Building..."
+        docker build -t nginx-lua:alpine-test .
+        echo "[DEBUG] Testing..."
+        docker run  --entrypoint nginx nginx-lua:alpine-test -version | tee nginx.version
+        if [[ $(cat nginx.version | grep "nginx/1.24.0" | wc -l) -le 0 ]]; then exit 1; fi

--- a/.github/workflows/dockerimage-test.yml
+++ b/.github/workflows/dockerimage-test.yml
@@ -19,5 +19,5 @@ jobs:
         echo "[DEBUG] Building..."
         docker build -t nginx-lua:alpine-test .
         echo "[DEBUG] Testing..."
-        echo $(docker run  --entrypoint nginx nginx-lua:alpine-test -version 2>&1 | tee nginx.version
+        docker run  --entrypoint nginx nginx-lua:alpine-test -version 2>&1 | tee nginx.version
         if [[ $(cat nginx.version | grep "nginx/1.24.0" | wc -l) -le 0 ]]; then exit 1; fi

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,6 +1,9 @@
 name: Docker Image CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
 

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -1,18 +1,17 @@
-FROM alpine:3.8
+FROM alpine:3.18.0
 
 MAINTAINER Wang Shaobo <fireshooter@163.com>
 
 ENV LANG en_US.UTF-8
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
-ENV NGINX_VERSION 1.10.2
-ENV NGX_DEVEL_KIT_VERSION 0.3.1
-ENV LUA_NGINX_MODULE_VERSION 0.10.14
+ENV NGINX_VERSION 1.24.0
+ENV NGX_DEVEL_KIT_VERSION 0.3.2
+ENV LUA_NGINX_MODULE_VERSION 0.10.24
 
-# Install LUAJIT
-RUN apk add --no-cache luajit
+# Install LUAJIT and LUARestyCore
+RUN apk update && apk add --no-cache luajit lua-resty-core
 
-RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+RUN GPG_KEYS=13C82A63B603576156E30A4EA0EA981B66B0D967 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \
@@ -85,7 +84,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
+	&& gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$GPG_KEYS" \
 	&& gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
 	&& rm -r "$GNUPGHOME" nginx.tar.gz.asc \
 	&& mkdir -p /usr/src \


### PR DESCRIPTION
# What?

* Updated versions for nginx, ngx devel kit and lua module. 
* Updated alpine base version. 
* Updated keyserver since ha.pool.sks-keyserver.net is not available.

* Set the push docker image action to run only on push to master

# Why?

I started debugging this message that is shown with the latest upstream version:

```
2023/05/22 13:44:13 [alert] 1#1: detected a LuaJIT version which is not OpenResty's; many optimizations will be disabled and performance will be compromised (see https://github.com/openresty/luajit2 for OpenResty's LuaJIT or, even better, consider using the OpenResty releases from https://openresty.org/en/download.html)
nginx: [alert] detected a LuaJIT version which is not OpenResty's; many optimizations will be disabled and performance will be compromised (see https://github.com/openresty/luajit2 for OpenResty's LuaJIT or, even better, consider using the OpenResty releases from https://openresty.org/en/download.html)
```

Then found the keyserver was not available.

Also removed the mirrors update since it was not working ok.

Had to install `lua-resty-core` along `luajit` due to module not found messages. 